### PR TITLE
Adds LICENSE.md with ISC license text as mentioned in package.json

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,16 @@
+Internet Systems Consortium license
+===================================
+
+Copyright (c) 2022, Kelly Rankin, JulieThinx, Daniel Pritchett, Cameron Young
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.


### PR DESCRIPTION
This is a bit awkward because the ISC boilerplate I copied off the internet explicitly names owners and I didn't really know/care how we should sort that at the moment. I added the handles of the four folks who were online during the initial session as starting point.

<img width="854" alt="image" src="https://user-images.githubusercontent.com/147981/158213351-c927ad9e-0b73-4c72-a35d-29ff09549318.png">
